### PR TITLE
Set photo display order

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,7 +323,13 @@ class GfApi {
             op: CONST.LISTING_OPS.REPLACE,
             path: '/cover_photo',
             value: photo_obj.id
-        }];
+        },
+        {
+            op: CONST.LISTING.OPS.REPLACE,
+            path: '/photo/' + photo_obj.id + '/display_order',
+            Value: 1
+        }
+                    ];
         return await this.listing_patch(listing_id, patch);
     }
 


### PR DESCRIPTION
I found bug in sample code. In index.js in line 325 it should be additional field with display order because without it photo is set only as cover photo.
{
op: CONST.LISTING.OPS.REPLACE,
path: ‘/photo/’ + photo_obj.id + ‘/display_order’,
Value: 1
}